### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
--*- mode: org; fill-column:70 -*-
+-*- mode: org; fill-column:69 -*-
 
 This is a distribution of Org, a plain text notes and project planning
 tool for Emacs.


### PR DESCRIPTION
the linguistic basis for the master/main debate doesn't hold up. it isn't systemic racism. it's bad for free software, since it requires time commitment from hundreds of thousands of developers to make changes to arbitrary values if they don't want their automated processes to fail. 

the spatial complexity of changes required is on the order of `S(n^2)`, since `n` distributed systems could connect to `n` other distributed systems, thus having `n^2` links between them. all of these changes represent wasted time, which could have been invested on actual progress. 

However, it seems like a bunch of out of touch white surburbanites took it upon themselves to vanquish systemic racism once and for all by deciding `main` should be the new normal. Racism is over now. Thanks to Google, Facebook and Microsoft, white people never have to apologize for their parents' systemic racism again ... because master was changed to main. 

see ['master/main' debate](https://github.com/ectorepo/ectorepo#the-mastermain-debate) for more information